### PR TITLE
Add a Hebrew translation

### DIFF
--- a/app/src/main/res/values-he/strings.xml
+++ b/app/src/main/res/values-he/strings.xml
@@ -1,13 +1,13 @@
 <resources>
     <string name="app_name">Colombo</string>
 
-    <string name="search_query">Search</string>
+    <string name="search_query">חיפוש</string>
 
-    <string name="menu_home">Homepage</string>
-    <string name="menu_refresh">Refresh</string>
-    <string name="menu_incognito">Incognito Mode</string>
-    <string name="menu_share">Share</string>
-    <string name="menu_settings">Settings</string>
+    <string name="menu_home">דף הבית</string>
+    <string name="menu_refresh">רענון</string>
+    <string name="menu_incognito">גלישה בסתר</string>
+    <string name="menu_share">שיתוף</string>
+    <string name="menu_settings">הגדרות</string>
 
 
     <string name="dialog_ok">אשר</string>

--- a/app/src/main/res/values-he/strings.xml
+++ b/app/src/main/res/values-he/strings.xml
@@ -1,0 +1,179 @@
+<resources>
+    <string name="app_name">Colombo</string>
+
+    <string name="search_query">Search</string>
+
+    <string name="menu_home">Homepage</string>
+    <string name="menu_refresh">Refresh</string>
+    <string name="menu_incognito">Incognito Mode</string>
+    <string name="menu_share">Share</string>
+    <string name="menu_settings">Settings</string>
+
+
+    <string name="dialog_ok">אשר</string>
+    <string name="dialog_cancel">בטל</string>
+
+    <string name="msg_upload_failed">העלאה נכשלה</string>
+
+    <string name="pref_header_appearance">מראה</string>
+
+    <string name="pref_dynamic_colors">צבע דינמי</string>
+    <string name="pref_dynamic_colors_summary">שינוי צבע היישום לפי האתר</string>
+
+    <string name="navbar_tint">צביעת שורת הניווט</string>
+    <string name="navbar_tint_summary">התאמת צבע שורת הניווט לצבע האפליקציה. אפשרות זו לא חלה למכשירים בהם לחצני הניווט אינם על המסך</string>
+
+    <string name="pref_javascript">JavaScript</string>
+    <string name="pref_javascript_summary">באמצעות אפשרות זו ניתן לבחור האם Javacript ירוץ באתרים הרוצים להריצו.</string>
+
+    <string name="pref_location">שירותי מיקום</string>
+    <string name="pref_location_summary">אפשר לאתרים לגשת למיקומך</string>
+
+    <string name="pref_zoom">הגדלה</string>
+    <string name="pref_zoom_summary">אם אפשרות זו פעילה, ניתן להגדיל את דף האינטרנט באמצעות שתי אצבעות</string>
+
+    <string name="pref_header_about">על הדפדפן</string>
+
+    <string name="search_engines">שינוי מנוע החיפוש</string>
+    <string name="search_engines_summary">אם הטקסט בשורת הכתובת אינו כתובת אינטרנט, הדפדפן יחפש את הטקסט במנוע החיפוש שנבחר</string>
+
+    <string name="pref_light_icons">צלמיות כהות בשורת המצב</string>
+    <string name="pref_light_icons_summary">צבע האפליקציה יהיה בהיר יותר, והצלמיות בשורת הכתובת יהיו כהות</string>
+
+    <string name="pref_header_tutorial_summary">למד כיצד להשתמש בדפדפן זה</string>
+
+    <string name="pref_header_intro">מדריך</string>
+
+    <string name="pref_swipe_to_refresh">החלק כדי לרענן</string>
+    <string name="pref_swipe_to_refresh_summary">החלקה למעלה בקצה העליון של דף אינטרנט תרענן אותו</string>
+
+    <string name="pref_circle_progress">עיגול התקדמות</string>
+    <string name="pref_circle_progress_summary">עיגול שמראה כי הדף עדיין נטען</string>
+
+    <string name="search_open_dialog">פתח מחוץ לדפדפן</string>
+    <string name="search_open_dialog_summary">שינוי ההתנהגות כאשר נבחר קישור שיכול להיפתח על ידי יישום שונה</string>
+
+    <string name="pref_cookies">עוגיות</string>
+    <string name="pref_cookies_summary">אתרים שונים משתמשים בעוגיות כדי לשמור מידע, כגון פרטי ההתחברות</string>
+
+    <string name="homepage">דף הבית</string>
+    <string name="homepage_sumamry">שינוי דף הבית. אם שדה זה ריק, דף הבית יהיה מנוע החיפוש שנבחר</string>
+
+    <string name="home_bookmarks">סימניות בדף הבית</string>
+    <string name="home_bookmarks_description">דף הבית יכיל את הסימניות במקום דף אינטרנט</string>
+
+    <string name="pref_sticky_header">הסתר את שורת הכתובת</string>
+    <string name="pref_sticky_header_summary">הסתרת שורת החיפוש בעת גלילה למטה לחווית גלישה עמוקה יותר</string>
+
+    <string name="pref_adblock">חסימת פרסומות</string>
+    <string name="pref_adblock_summary">חסימת פרסומות. נסו לחשוב על האתרים שצריכים כסף, ותשדלו לכבות אפשרות זו</string>
+
+    <string name="pref_font_summary">Use Space Mono Font instead of Roboto</string>
+    <string name="pref_font">גופן מותאם אישית</string>
+
+    <string-array name="search_engines_titles">
+        <item>Google</item>
+        <item>Yahoo</item>
+        <item>DuckDuckGo</item>
+        <item>Bing</item>
+    </string-array>
+
+    <string-array name="search_engines_values">
+        <item>0</item>
+        <item>1</item>
+        <item>2</item>
+        <item>3</item>
+    </string-array>
+
+    <string-array name="search_open_dialog_titles">
+        <item>פתח תמיד</item>
+        <item>פתח באמצעות יישום חיצוני, במידה וקיים אחד</item>
+        <item>פתח קישור</item>
+    </string-array>
+
+    <string-array name="search_open_dialog_values">
+        <item>0</item>
+        <item>1</item>
+        <item>2</item>
+    </string-array>
+
+    <string name="menu_open_new">פתח בדף חדש</string>
+    <string name="menu_open_new_link">פתח קישור זה בדף חדש</string>
+    <string name="menu_open_save_bookmark">הוספת סימניה</string>
+    <string name="menu_save_image">שמור תמונה</string>
+    <string name="menu_open_copy_link">העתק קישור</string>
+    <string name="menu_open_share_link">שתף קישור</string>
+
+    <string name="menu_rename">שנה שם</string>
+    <string name="menu_delete">מחק</string>
+    <string name="menu_continue">המשך</string>
+    <string name="menu_open">פתח</string>
+    <string name="menu_new">דף חדש</string>
+    <string name="menu_dekstop">תצוגת מחשב</string>
+    <string name="menu_add">הוספה למסך הבית</string>
+
+    <string name="general_2_title">חיפוש</string>
+    <string name="general_3_title">אחרים</string>
+    <string name="pref_header_general">כללי</string>
+    <string name="general_1_title">אתרים</string>
+    <string name="appearence_1_title">ממשק</string>
+    <string name="appearence_2_title">UX</string>
+
+    <string name="title_1">מחוות</string>
+    <string name="description_1">ניווט קדימה ואחורה בהיסטורית הגלישה באמצעות מחוות</string>
+
+    <string name="title_2">מועדפים</string>
+    <string name="description_2">לחיצה ארוכה על שורת הכתובת תוסיף לדף הנוכחי סימניה</string>
+    <string name="title_3">תוכן</string>
+    <string name="description_3">לחיצה ארוכה על טקסט או תמונה תציג תפריט פעולות</string>
+
+    <string name="gestures">מחוות</string>
+    <string name="gestures_description">ניווט קדימה ואחורה בהיסטורית הגלישה באמצעות מחוות</string>
+
+    <string name="menu_search_words">מצא בתוך הדף</string>
+
+    <string name="menu_bookmark">סימניות</string>
+    <string name="app_name_incognito">גלישה בסתר</string>
+    <string name="no_connection">המשך הגלישה דורש חיבור לרשת</string>
+    <string name="tutorial">האם ברצונכם לעבור את ההדרכה הראשונית</string>
+    <string name="description_about">דפדפן קל, מהיר</string>
+    <string name="description_about_2">ומקסים</string>
+    <string name="team_text">הקבוצה</string>
+    <string name="libs_text">ספריות</string>
+    <string name="links_text">עוד</string>
+    <string name="title_activity_feedback">משוב</string>
+
+    <string name="add_bookmark_title">הוסף סימניה</string>
+    <string name="add_bookmark_content">נא לתת לסימניה שם</string>
+    <string name="tabs_error">דפים מרובים אפשריים באנדרואיד 5 ומעלה</string>
+    <string name="rename_bookmark_title">שנה שם לסימניה</string>
+    <string name="rename_bookmark_content">שינוי שם הסימניה</string>
+    <string name="delete_bookmark_title">מחק סימניה</string>
+    <string name="delete_bookmark_content">האם ברצונכם למחוק</string>
+    <string name="delete_bookmark_positive">מחק</string>
+    <string name="delete_bookmark_negative">בטל</string>
+    <string name="url_search_summary">הראה טקסט לחיפוש במקום כתובת</string>
+    <string name="url_search">טקסט לחיפוש</string>
+    <string name="restart_colombo">התחל את היישום מחדש כדי להחיל את השינויים</string>
+    <string name="link_error">הדפדפן לא הצליח להבין כתובת זו</string>
+    <string name="pref_plugins">הרחבות</string>
+    <string name="pref_plugins_summary">אתרים מסוימים דורשים הרחבות כדי לפעול כראוי</string>
+    <string name="home_hw_description">האצה חומרתית יכולה לשפר את הביצועים אך לפגוע בחיי הסוללה</string>
+    <string name="home_hw">האצה חומרתית</string>
+    <string name="title_activity_history">היסטוריה</string>
+    <string name="menu_clear">נקה הכל</string>
+    <string name="menu_history">היסטוריה</string>
+    <string name="title_activity_donation">תרומות</string>
+    <string name="pref_header_donation">תרמו לי</string>
+    <string name="donations_coke">קנו לי קולה</string>
+    <string name="donations_brioches">קנו לי בריוש</string>
+    <string name="donations_kebab">קנו לי קבב</string>
+    <string name="donations_king">קנו לי ארוחת מלכים</string>
+    <string name="donations_present">קנו לי מתנה</string>
+    <string name="donations_pc">קנו לי מחשב חדש</string>
+
+    <string name="title_activity_about" translatable="false">אודות</string>
+    <string name="pref_header_general_summary">אפשרויות כלליות לאתרים ועוד</string>
+    <string name="pref_header_appearance_summary">הענקת מראה משופר לדפדפן</string>
+
+</resources>


### PR DESCRIPTION
I have translated your app to Hebrew! Note that Hebrew is a right-to-left language, and that means that you should set the app up to use right-to-left menus while in Hebrew, Arabic, Farsi, Urdu, and so on.